### PR TITLE
Fix version detection, versionSection creation

### DIFF
--- a/bootstrap-salt.ps1
+++ b/bootstrap-salt.ps1
@@ -228,19 +228,20 @@ If (!$version) {
         $returnMatches = $returnMatches | Where {$_ -like "Salt-Minion*AMD64-Setup.exe"}
     }
 
-    $version = $($returnMatches[$returnMatches.Count -1]).Split(("n-","-A","-x"),([System.StringSplitOptions]::RemoveEmptyEntries))[1]
+    $version = $($returnMatches[$returnMatches.Count -1]).Split(("n-","-A","-x","-P"),([System.StringSplitOptions]::RemoveEmptyEntries))[1]
 }
 
-$year = $version.Substring(0, 3)
+$versionSection = $version
+
+$year = $version.Substring(0, 4)
 If ([int]$year -ge 2017) {
     If ($pythonVersion -eq "3") {
-        $pythonVersion = "-Py3"
+        $versionSection = "$version-Py3"
     }
     Else {
-        $pythonVersion = "-Py2"
+        $versionSection = "$version-Py2"
     }
 }
-$versionSection = $version + $pythonVersion
 
 #===============================================================================
 # Download minion setup file


### PR DESCRIPTION
### What does this PR do?
Fixes version detection
Fixes problem with year, 2017 was returning 201
Fixes problem setting $pythonVersion to '-Py3' or '-Py2'. Powershell validates variables. `$pythonVersion` was defined to have acceptable values of ['2', '3']
